### PR TITLE
Default what to window because 99% ..

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
  * @api public
  */
 function prefixes(what, where) {
+  where = where || window;
   if (what in where) return where[what];
   else for (var i = 0, key; i < prefixes.vendor.length; i++) {
     key = prefixes.vendor[i] + what.charAt(0).toUpperCase() + what.slice(1);


### PR DESCRIPTION
Default what to window because in 99% of the situations that's what it is.

And because the default example in the README won't work otherwise.
